### PR TITLE
Add R3GAN loss integration for SRModel

### DIFF
--- a/traiNNer/losses/r3gan_loss.py
+++ b/traiNNer/losses/r3gan_loss.py
@@ -1,0 +1,154 @@
+"""R3GAN adversarial loss implementation.
+
+This module implements the relativistic adversarial loss used by the
+R3GAN baseline ("The GAN is dead; long live the GAN! A Modern Baseline GAN").
+It adapts the generator and discriminator losses described in the reference
+implementation to the traiNNer-redux training pipeline.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from torch import Tensor, autograd, nn
+from torch.nn import functional as F
+
+from traiNNer.utils.registry import LOSS_REGISTRY
+
+
+def _identity(x: Tensor) -> Tensor:
+    return x
+
+
+@LOSS_REGISTRY.register()
+class R3GANLoss(nn.Module):
+    """Relativistic GAN loss with zero-centered gradient penalties.
+
+    The implementation mirrors the public R3GAN repository while adapting the
+    interface to match traiNNer-redux's loss construction. The loss computes a
+    relativistic logistic adversarial objective paired with zero-centered
+    gradient penalties on both real and generated samples.
+
+    Args:
+        loss_weight (float): Multiplier applied when the loss is used for the
+            generator. The discriminator always uses a multiplier of ``1``.
+        gamma (float): Weight for the zero-centered gradient penalty term. The
+            final discriminator loss becomes ``adv + gamma / 2 * (r1 + r2)``.
+        preprocess (Callable | None): Optional callable applied to the input
+            samples before being fed to the discriminator. When ``None`` an
+            identity transform is used. This mirrors the augmentation pipeline
+            hook provided by the original R3GAN codebase.
+    """
+
+    def __init__(
+        self,
+        loss_weight: float,
+        gamma: float = 1.0,
+        preprocess: Callable[[Tensor], Tensor] | None = None,
+    ) -> None:
+        super().__init__()
+        self.loss_weight = loss_weight
+        self.gamma = gamma
+        self.preprocess = preprocess or _identity
+
+    def forward(self, *args, **kwargs) -> Tensor:  # pragma: no cover - handled explicitly
+        raise RuntimeError(
+            "R3GANLoss.forward is not used directly. Call ``generator_forward`` "
+            "or ``discriminator_forward`` instead."
+        )
+
+    @staticmethod
+    def _zero_centered_gradient_penalty(samples: Tensor, critics: Tensor) -> Tensor:
+        gradient, = autograd.grad(
+            outputs=critics.sum(), inputs=samples, create_graph=True
+        )
+        return gradient.square().sum(dim=[1, 2, 3])
+
+    def generator_forward(
+        self,
+        net_d: nn.Module,
+        fake_samples: Tensor,
+        real_samples: Tensor,
+    ) -> tuple[Tensor, dict[str, Tensor]]:
+        """Compute the generator loss.
+
+        Args:
+            net_d (nn.Module): Discriminator network.
+            fake_samples (Tensor): Generated samples (requires gradient).
+            real_samples (Tensor): Real samples used for the relativistic term.
+
+        Returns:
+            tuple: A tuple containing the scalar generator loss tensor and a
+            dictionary with detached diagnostic tensors.
+        """
+
+        processed_fake = self.preprocess(fake_samples)
+        with torch.no_grad():
+            processed_real = self.preprocess(real_samples.detach())
+            real_logits = net_d(processed_real)
+
+        fake_logits = net_d(processed_fake)
+        relativistic_logits = fake_logits - real_logits
+        adversarial_loss = F.softplus(-relativistic_logits).mean()
+
+        diagnostics = {
+            "relativistic_logits": relativistic_logits.detach(),
+            "fake_logits": fake_logits.detach(),
+            "real_logits": real_logits.detach(),
+        }
+
+        return adversarial_loss, diagnostics
+
+    def discriminator_forward(
+        self,
+        net_d: nn.Module,
+        real_samples: Tensor,
+        fake_samples: Tensor,
+    ) -> dict[str, Tensor]:
+        """Compute the discriminator loss and auxiliary statistics.
+
+        Args:
+            net_d (nn.Module): Discriminator network.
+            real_samples (Tensor): Real input images.
+            fake_samples (Tensor): Generated images from the generator.
+
+        Returns:
+            dict[str, Tensor]: Dictionary containing the total loss and
+            diagnostics. The ``total_loss`` entry should be used for the
+            backward pass.
+        """
+
+        real_detached = real_samples.detach().requires_grad_(True)
+        fake_detached = fake_samples.detach().requires_grad_(True)
+
+        processed_real = self.preprocess(real_detached)
+        processed_fake = self.preprocess(fake_detached)
+
+        real_logits = net_d(processed_real)
+        fake_logits = net_d(processed_fake)
+
+        relativistic_logits = real_logits - fake_logits
+        adversarial_loss = F.softplus(-relativistic_logits).mean()
+
+        r1_penalty = self._zero_centered_gradient_penalty(
+            real_detached, real_logits
+        ).mean()
+        r2_penalty = self._zero_centered_gradient_penalty(
+            fake_detached, fake_logits
+        ).mean()
+
+        r1_contrib = 0.5 * self.gamma * r1_penalty
+        r2_contrib = 0.5 * self.gamma * r2_penalty
+        total_loss = adversarial_loss + r1_contrib + r2_contrib
+
+        return {
+            "total_loss": total_loss,
+            "adversarial_loss": adversarial_loss,
+            "r1_penalty": r1_penalty,
+            "r2_penalty": r2_penalty,
+            "r1_contrib": r1_contrib,
+            "r2_contrib": r2_contrib,
+            "relativistic_logits": relativistic_logits.detach(),
+            "real_logits": real_logits.detach(),
+            "fake_logits": fake_logits.detach(),
+        }

--- a/traiNNer/models/sr_model.py
+++ b/traiNNer/models/sr_model.py
@@ -22,6 +22,7 @@ from traiNNer.archs import build_network
 from traiNNer.archs.arch_info import ARCHS_WITHOUT_FP16
 from traiNNer.data.base_dataset import BaseDataset
 from traiNNer.losses import build_loss
+from traiNNer.losses.r3gan_loss import R3GANLoss
 from traiNNer.metrics import calculate_metric
 from traiNNer.models.base_model import BaseModel
 from traiNNer.utils import get_root_logger, imwrite, tensor2img
@@ -269,7 +270,7 @@ class SRModel(BaseModel):
             assert "loss_weight" in loss, f"{loss['type']} must define loss_weight"
             if float(loss["loss_weight"]) != 0:
                 label = loss_type_to_label(loss["type"])
-                if label == "l_g_gan":
+                if label in {"l_g_gan", "l_g_r3gan"}:
                     self.has_gan = True
                 self.losses[label] = build_loss(loss).to(
                     self.device,
@@ -419,10 +420,21 @@ class SRModel(BaseModel):
                                 )
                         target = lq_target
 
-                    if label == "l_g_gan":
+                    if label in {"l_g_gan", "l_g_r3gan"}:
                         assert self.net_d is not None
-                        fake_g_pred = self.net_d(self.output)
-                        l_g_loss = loss(fake_g_pred, True, is_disc=False)
+                        if isinstance(loss, R3GANLoss):
+                            assert self.gt is not None
+                            l_g_loss, r3gan_logs = loss.generator_forward(
+                                self.net_d,
+                                self.output,
+                                self.gt,
+                            )
+                            loss_dict["relativistic_logits_g"] = (
+                                r3gan_logs["relativistic_logits"].mean()
+                            )
+                        else:
+                            fake_g_pred = self.net_d(self.output)
+                            l_g_loss = loss(fake_g_pred, True, is_disc=False)
 
                         if self.adaptive_d:
                             l_g_gan_ema = (
@@ -505,6 +517,8 @@ class SRModel(BaseModel):
                     assert isinstance(self.output, Tensor)
 
         cri_gan = self.losses.get("l_g_gan")
+        if cri_gan is None:
+            cri_gan = self.losses.get("l_g_r3gan")
 
         if (
             self.net_d is not None
@@ -521,18 +535,41 @@ class SRModel(BaseModel):
                 dtype=self.amp_dtype,
                 enabled=self.use_amp,
             ):
-                # real
-                real_d_pred = self.net_d(self.gt)
-                l_d_real = cri_gan(real_d_pred, True, is_disc=True)
-                loss_dict["l_d_real"] = l_d_real
-                loss_dict["out_d_real"] = torch.mean(real_d_pred.detach())
-                # fake
-                fake_d_pred = self.net_d(self.output.detach())
-                l_d_fake = cri_gan(fake_d_pred, False, is_disc=True)
-                loss_dict["l_d_fake"] = l_d_fake
-                loss_dict["out_d_fake"] = torch.mean(fake_d_pred.detach())
+                if isinstance(cri_gan, R3GANLoss):
+                    assert self.gt is not None
+                    r3gan_stats = cri_gan.discriminator_forward(
+                        self.net_d,
+                        self.gt,
+                        self.output.detach(),
+                    )
+                    l_d_total = r3gan_stats["total_loss"]
+                    loss_dict["l_d_total"] = l_d_total
+                    loss_dict["l_d_adv"] = r3gan_stats["adversarial_loss"]
+                    loss_dict["l_d_r1"] = r3gan_stats["r1_contrib"]
+                    loss_dict["l_d_r2"] = r3gan_stats["r2_contrib"]
+                    loss_dict["l_d_real"] = r3gan_stats["adversarial_loss"]
+                    loss_dict["l_d_fake"] = (
+                        r3gan_stats["r1_contrib"] + r3gan_stats["r2_contrib"]
+                    )
+                    loss_dict["out_d_real"] = torch.mean(
+                        r3gan_stats["real_logits"]
+                    )
+                    loss_dict["out_d_fake"] = torch.mean(
+                        r3gan_stats["fake_logits"]
+                    )
+                else:
+                    real_d_pred = self.net_d(self.gt)
+                    l_d_real = cri_gan(real_d_pred, True, is_disc=True)
+                    loss_dict["l_d_real"] = l_d_real
+                    loss_dict["out_d_real"] = torch.mean(real_d_pred.detach())
+                    fake_d_pred = self.net_d(self.output.detach())
+                    l_d_fake = cri_gan(fake_d_pred, False, is_disc=True)
+                    loss_dict["l_d_fake"] = l_d_fake
+                    loss_dict["out_d_fake"] = torch.mean(fake_d_pred.detach())
+                    l_d_total = l_d_real + l_d_fake
+                    loss_dict["l_d_total"] = l_d_total
 
-            self.scaler_d.scale((l_d_real + l_d_fake) / self.accum_iters).backward()
+            self.scaler_d.scale(l_d_total / self.accum_iters).backward()
 
             if apply_gradient:
                 self.scaler_d.unscale_(self.optimizer_d)


### PR DESCRIPTION
## Summary
- add an R3GAN adversarial loss module with relativistic logits and zero-centered gradient penalties
- integrate the new loss into the SRModel generator and discriminator training flow, including adaptive logging

## Testing
- python -m compileall traiNNer/losses/r3gan_loss.py traiNNer/models/sr_model.py

------
https://chatgpt.com/codex/tasks/task_e_68d6c76a38908324ba4b4f15b502fee0